### PR TITLE
Convert to open sourced random name generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@
 
 # Generated typings
 src/**/*.d.ts
+
+# Idea IDE
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -5712,12 +5712,6 @@
         "minimist": "0.0.8"
       }
     },
-    "moniker": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/moniker/-/moniker-0.1.2.tgz",
-      "integrity": "sha1-hy37pXXc6o+gSlE1sT1fJL7MyX4=",
-      "dev": true
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -6223,6 +6217,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "project-name-generator": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/project-name-generator/-/project-name-generator-2.1.6.tgz",
+      "integrity": "sha512-5r5MzHoNf7GTKg0V7zZvolpip5UAQiVpfcSN6QfEK8i/fSKlusJwxzEsKty9ce8h0e5GLoQ85dIGgV1TAnj3Kg==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.15.1",
+        "lodash": "^4.17.10"
+      }
     },
     "promise-inflight": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "karma-spec-reporter": "^0.0.32",
     "karma-summary-reporter": "^1.5.2",
     "karma-webpack": "^3.0.5",
-    "moniker": "^0.1.2",
+    "project-name-generator": "^2.1.6",
     "ts-loader": "^5.3.2",
     "ts-node": "^8.0.0",
     "tslint": "^5.12.0",

--- a/tests/karma/common.ts
+++ b/tests/karma/common.ts
@@ -20,18 +20,11 @@
  * IN THE SOFTWARE.
  */
 
-import * as moniker from "moniker"
 import * as path from "path"
 
-import {
-  Config as KarmaConfig,
-  ConfigOptions as KarmaConfigOptions
-} from "karma"
-import {
-  Configuration as WebpackConfig,
-  ProvidePlugin,
-  RuleSetRule as WebpackRuleSetRule
-} from "webpack"
+import { Config as KarmaConfig, ConfigOptions as KarmaConfigOptions } from "karma"
+import { generate } from "project-name-generator"
+import { Configuration as WebpackConfig, ProvidePlugin, RuleSetRule as WebpackRuleSetRule } from "webpack"
 
 /* ----------------------------------------------------------------------------
  * Functions
@@ -58,13 +51,13 @@ export function webpack(
         },
         ...(config.singleRun
           ? [
-              ({
-                test: /\.ts$/,
-                use: "istanbul-instrumenter-loader?+esModules",
-                include: path.resolve(__dirname, "../../src"),
-                enforce: "post"
-              }) as WebpackRuleSetRule
-            ]
+            ({
+              test: /\.ts$/,
+              use: "istanbul-instrumenter-loader?+esModules",
+              include: path.resolve(__dirname, "../../src"),
+              enforce: "post"
+            }) as WebpackRuleSetRule
+          ]
           : [])
       ]
     },
@@ -112,7 +105,7 @@ export function saucelabs(
       build: process.env.TRAVIS_BUILD_NUMBER,
       testName: process.env.TRAVIS
         ? `${process.env.TRAVIS_REPO_SLUG} #${process.env.TRAVIS_BUILD_NUMBER}`
-        : `~ #${moniker.choose()}`,
+        : `~ #${generate().dashed}`,
       recordVideo: false,
       recordScreenshots: false
     },

--- a/typings/project-name-generator.d.ts
+++ b/typings/project-name-generator.d.ts
@@ -20,6 +20,6 @@
  * IN THE SOFTWARE.
  */
 
-declare module "moniker" {
-  export function choose(): string
+declare module "project-name-generator" {
+  export function generate(): { raw: string, dashed: string, spaced: string }
 }


### PR DESCRIPTION
Although `moniker` is a widely used random string generator, it is unlicensed. I recommend converting to an open source random string generator such as `project-name-generator` so that developers can feel confident they are covered by an open source license when selecting `karama-viewport`.

project-name-generator can be found at https://github.com/aceakash/project-name-generator

