### PR TITLE
Serve all files, but don't put the .map in script tag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,10 +76,10 @@ declare global {
  *
  * @return File pattern
  */
-const pattern = (file: string, served: boolean = true): FilePattern => ({
+const pattern = (file: string, included: boolean = true): FilePattern => ({
   pattern: file,
-  included: true,
-  served,
+  included,
+  served: true,
   watched: false
 })
 


### PR DESCRIPTION
Fixes issue https://github.com/squidfunk/karma-viewport/issues/509

Verified with
1.  `npm run test` in karma-viewport
2. `npm run build` in karma-viewport and 
  ```
  plugins: [
      require('C:\\Users\\jurri\\repos\\external\\karma-viewport\\dist\\'),
  ```
  in my project's `karma.conf.js` which has several tests that modify the viewport.

@squidfunk - if you can issue a bugfix release that would be greatly appreciated 😃 